### PR TITLE
Add native rolling TDA driver and tests

### DIFF
--- a/python/torpedocode/features/topological.py
+++ b/python/torpedocode/features/topological.py
@@ -8,8 +8,9 @@ landscapes and images as specified in :class:`TopologyConfig`.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 import warnings
+import json
 from typing import Optional, Tuple, Iterable, List
 
 import numpy as np
@@ -84,6 +85,21 @@ class TopologicalFeatureGenerator:
         wlist = (
             list(window_sizes_s) if window_sizes_s is not None else list(self.config.window_sizes_s)
         )
+        if _tda_native is not None and hasattr(_tda_native, "rolling_topo"):
+            try:
+                cfg_json = json.dumps(asdict(self.config))
+                arr = np.asarray(series, dtype=np.float64, order="C")
+                out = _tda_native.rolling_topo(
+                    arr,
+                    ts_ns.astype(np.int64, copy=False),
+                    [int(w) for w in wlist],
+                    int(stride),
+                    cfg_json,
+                )
+                return np.asarray(out, dtype=np.float32)
+            except Exception:
+                if self._strict():
+                    raise
         reps_all = []
         for w in wlist:
             w_ns = int(w) * 1_000_000_000
@@ -366,6 +382,32 @@ class TopologicalFeatureGenerator:
             raise ValueError(f"Unsupported representation {self.config.persistence_representation}")
 
     def _landscape(self, diag: List[np.ndarray]) -> np.ndarray:
+        if _tda_native is not None and hasattr(_tda_native, "persistence_landscape"):
+            levels = int(self.config.landscape_levels)
+            summary_mode = str(getattr(self.config, "landscape_summary", "mean"))
+            resolution = int(getattr(self.config, "landscape_resolution", 64) or 64)
+            if resolution <= 0:
+                resolution = 64
+            try:
+                vecs = []
+                for D in diag[: self.config.max_homology_dimension + 1]:
+                    if not isinstance(D, np.ndarray) or D.size == 0:
+                        vecs.append(np.zeros((levels,), dtype=np.float32))
+                        continue
+                    arr = np.asarray(D, dtype=np.float64)
+                    out = _tda_native.persistence_landscape(
+                        arr,
+                        levels,
+                        resolution,
+                        summary_mode,
+                    )
+                    vecs.append(np.asarray(out, dtype=np.float32))
+                if vecs:
+                    return np.concatenate(vecs, axis=0)
+            except Exception:
+                if self._strict():
+                    raise
+
         try:
             from persim import PersLandscapeApprox
         except Exception:
@@ -406,6 +448,38 @@ class TopologicalFeatureGenerator:
         return np.concatenate(grids, axis=0)
 
     def _image(self, diag: List[np.ndarray]) -> np.ndarray:
+        if _tda_native is not None and hasattr(_tda_native, "persistence_image"):
+            res = int(self.config.image_resolution)
+            sigma = float(getattr(self.config, "image_bandwidth", 0.05))
+            birth_range = getattr(self, "_active_birth_range", None) or getattr(
+                self.config, "image_birth_range", None
+            )
+            pers_range = getattr(self, "_active_pers_range", None) or getattr(
+                self.config, "image_pers_range", None
+            )
+            try:
+                imgs = []
+                for D in diag[: self.config.max_homology_dimension + 1]:
+                    if not isinstance(D, np.ndarray) or D.size == 0:
+                        imgs.append(np.zeros((res * res,), dtype=np.float32))
+                        continue
+                    B = np.asarray(D[:, 0], dtype=np.float64)
+                    P = np.asarray(D[:, 1], dtype=np.float64)
+                    out = _tda_native.persistence_image(
+                        B,
+                        P,
+                        res,
+                        sigma,
+                        birth_range,
+                        pers_range,
+                    )
+                    imgs.append(np.asarray(out, dtype=np.float32))
+                if imgs:
+                    return np.concatenate(imgs, axis=0)
+            except Exception:
+                if self._strict():
+                    raise
+
         try:
             from persim import PersistenceImager
         except Exception:

--- a/rust/torpedocode-tda/Cargo.lock
+++ b/rust/torpedocode-tda/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +94,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memoffset"
@@ -312,10 +324,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "smallvec"
@@ -348,6 +409,8 @@ dependencies = [
  "numpy",
  "pyo3",
  "rayon",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/rust/torpedocode-tda/Cargo.toml
+++ b/rust/torpedocode-tda/Cargo.toml
@@ -12,4 +12,6 @@ pyo3 = { version = "0.20", features = ["extension-module"] }
 numpy = "0.20"
 ndarray = { version = "0.15", features = ["rayon"] }
 rayon = "1.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 

--- a/rust/torpedocode-tda/src/lib.rs
+++ b/rust/torpedocode-tda/src/lib.rs
@@ -1,8 +1,14 @@
 #![deny(warnings)]
-use ndarray::Array2;
-use numpy::PyReadonlyArray2;
+use ndarray::parallel::prelude::*;
+use ndarray::{s, Array2, ArrayView2, Axis};
+use numpy::{PyArray1, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use numpy::PyReadonlyArray1;
+use pyo3::types::{PyDict, PyList, PyModule, PyTuple};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::sync::Arc;
 
 fn l2_distance_matrix(x: &Array2<f64>) -> Array2<f64> {
     let n = x.nrows();
@@ -25,12 +31,10 @@ fn l2_distance_matrix(x: &Array2<f64>) -> Array2<f64> {
     d
 }
 
-#[pyfunction]
-fn estimate_vr_epsilon<'py>(_py: Python<'py>, x: PyReadonlyArray2<f64>, q: f64) -> PyResult<f64> {
-    let x = x.as_array();
+fn estimate_vr_epsilon_impl(x: &Array2<f64>, q: f64) -> f64 {
     let n = x.nrows();
     if n <= 1 {
-        return Ok(1.0);
+        return 1.0;
     }
     if n == 2 {
         let mut s = 0.0;
@@ -38,10 +42,9 @@ fn estimate_vr_epsilon<'py>(_py: Python<'py>, x: PyReadonlyArray2<f64>, q: f64) 
             let diff = x[(0, k)] - x[(1, k)];
             s += diff * diff;
         }
-        return Ok(s.sqrt());
+        return s.sqrt();
     }
-    let d = l2_distance_matrix(&x.to_owned());
-    // Prim's algorithm to build MST and collect edge weights
+    let d = l2_distance_matrix(x);
     let mut in_tree = vec![false; n];
     let mut min_edge = vec![f64::INFINITY; n];
     in_tree[0] = true;
@@ -72,18 +75,26 @@ fn estimate_vr_epsilon<'py>(_py: Python<'py>, x: PyReadonlyArray2<f64>, q: f64) 
         }
     }
     if edges.is_empty() {
-        return Ok(1.0);
+        return 1.0;
     }
-    edges.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    edges.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
     let m = edges.len();
     let k = ((q.clamp(0.0, 1.0)) * (m as f64)).ceil() as usize;
     let idx = if k == 0 { 0 } else { k.saturating_sub(1) };
-    Ok(edges[idx])
+    edges[idx]
+}
+
+#[pyfunction]
+fn estimate_vr_epsilon<'py>(_py: Python<'py>, x: PyReadonlyArray2<f64>, q: f64) -> PyResult<f64> {
+    let x = x.as_array();
+    Ok(estimate_vr_epsilon_impl(&x.to_owned(), q))
 }
 
 fn lcc_fraction(d: &Array2<f64>, eps: f64) -> f64 {
     let n = d.nrows();
-    if n == 0 { return 0.0; }
+    if n == 0 {
+        return 0.0;
+    }
     let mut adj: Vec<Vec<usize>> = vec![Vec::new(); n];
     for i in 0..n {
         for j in 0..n {
@@ -95,7 +106,9 @@ fn lcc_fraction(d: &Array2<f64>, eps: f64) -> f64 {
     let mut visited = vec![false; n];
     let mut best = 0usize;
     for i in 0..n {
-        if visited[i] { continue; }
+        if visited[i] {
+            continue;
+        }
         let mut stack: Vec<usize> = vec![i];
         visited[i] = true;
         let mut size = 0usize;
@@ -108,27 +121,38 @@ fn lcc_fraction(d: &Array2<f64>, eps: f64) -> f64 {
                 }
             }
         }
-        if size > best { best = size; }
-        if best as f64 >= 0.9999 * (n as f64) { break; }
+        if size > best {
+            best = size;
+        }
+        if best as f64 >= 0.9999 * (n as f64) {
+            break;
+        }
     }
     best as f64 / (n as f64)
 }
 
-#[pyfunction]
-fn epsilon_for_lcc<'py>(_py: Python<'py>, x: PyReadonlyArray2<f64>, threshold: f64) -> PyResult<f64> {
-    let x = x.as_array();
+fn epsilon_for_lcc_impl(x: &Array2<f64>, threshold: f64) -> f64 {
     let n = x.nrows();
-    if n <= 1 { return Ok(0.0); }
-    let d = l2_distance_matrix(&x.to_owned());
-    // Collect unique finite distances as candidate epsilons
+    if n <= 1 {
+        return 0.0;
+    }
+    let d = l2_distance_matrix(x);
     let mut vals: Vec<f64> = Vec::with_capacity(n * n);
-    for i in 0..n { for j in 0..n { let w = d[(i,j)]; if w.is_finite() { vals.push(w); } } }
-    if vals.is_empty() { return Ok(1.0); }
-    vals.sort_by(|a,b| a.partial_cmp(b).unwrap());
-    vals.dedup_by(|a,b| (*a - *b).abs() <= std::f64::EPSILON);
-    // Monotone binary search for minimal epsilon achieving threshold LCC fraction
+    for i in 0..n {
+        for j in 0..n {
+            let w = d[(i, j)];
+            if w.is_finite() {
+                vals.push(w);
+            }
+        }
+    }
+    if vals.is_empty() {
+        return 1.0;
+    }
+    vals.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    vals.dedup_by(|a, b| (*a - *b).abs() <= f64::EPSILON);
     let mut lo = 0usize;
-    let mut hi = vals.len()-1;
+    let mut hi = vals.len().saturating_sub(1);
     let mut ans = vals[hi];
     while lo <= hi {
         let mid = (lo + hi) / 2;
@@ -136,14 +160,776 @@ fn epsilon_for_lcc<'py>(_py: Python<'py>, x: PyReadonlyArray2<f64>, threshold: f
         let frac = lcc_fraction(&d, eps);
         if frac >= threshold {
             ans = eps;
-            if mid == 0 { break; }
-            hi = mid - 1;
+            if mid == 0 {
+                break;
+            }
+            hi = mid.saturating_sub(1);
         } else {
-            if mid == vals.len()-1 { break; }
+            if mid == vals.len() - 1 {
+                break;
+            }
             lo = mid + 1;
         }
     }
-    Ok(ans)
+    ans
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RollingConfig {
+    complex_type: String,
+    max_homology_dimension: usize,
+    persistence_representation: String,
+    landscape_levels: Option<usize>,
+    landscape_summary: Option<String>,
+    landscape_resolution: Option<usize>,
+    image_resolution: Option<usize>,
+    image_bandwidth: Option<f64>,
+    image_birth_range: Option<(f64, f64)>,
+    image_pers_range: Option<(f64, f64)>,
+    image_auto_range: Option<bool>,
+    vr_auto_epsilon: Option<bool>,
+    vr_connectivity_quantile: Option<f64>,
+    vr_epsilon_rule: Option<String>,
+    vr_lcc_threshold: Option<f64>,
+    vr_zscore: Option<bool>,
+    use_liquidity_surface: Option<bool>,
+    levels_hint: Option<usize>,
+    imbalance_eps: Option<f64>,
+    cubical_scalar_field: Option<String>,
+}
+
+impl RollingConfig {
+    fn max_dim(&self) -> usize {
+        self.max_homology_dimension
+    }
+
+    fn landscape_levels(&self) -> usize {
+        self.landscape_levels.unwrap_or(5)
+    }
+
+    fn landscape_summary(&self) -> &str {
+        self.landscape_summary.as_deref().unwrap_or("mean")
+    }
+
+    fn landscape_resolution(&self) -> usize {
+        self.landscape_resolution.unwrap_or(64)
+    }
+
+    fn image_resolution(&self) -> usize {
+        self.image_resolution.unwrap_or(64)
+    }
+
+    fn image_bandwidth(&self) -> f64 {
+        self.image_bandwidth.unwrap_or(0.05)
+    }
+
+    fn image_auto_range(&self) -> bool {
+        self.image_auto_range.unwrap_or(true)
+    }
+
+    fn vr_auto_epsilon(&self) -> bool {
+        self.vr_auto_epsilon.unwrap_or(true)
+    }
+
+    fn vr_connectivity_quantile(&self) -> f64 {
+        self.vr_connectivity_quantile.unwrap_or(0.99)
+    }
+
+    fn vr_epsilon_rule(&self) -> &str {
+        self.vr_epsilon_rule.as_deref().unwrap_or("largest_cc")
+    }
+
+    fn vr_lcc_threshold(&self) -> f64 {
+        self.vr_lcc_threshold.unwrap_or(0.99)
+    }
+
+    fn vr_zscore(&self) -> bool {
+        self.vr_zscore.unwrap_or(true)
+    }
+
+    fn use_liquidity_surface(&self) -> bool {
+        self.use_liquidity_surface.unwrap_or(true)
+    }
+
+    fn levels_hint(&self) -> Option<usize> {
+        self.levels_hint
+    }
+
+    fn imbalance_eps(&self) -> f64 {
+        self.imbalance_eps.unwrap_or(1e-6)
+    }
+
+    fn cubical_scalar_field(&self) -> &str {
+        self.cubical_scalar_field.as_deref().unwrap_or("imbalance")
+    }
+}
+
+fn embedding_dim(cfg: &RollingConfig) -> usize {
+    match cfg.persistence_representation.as_str() {
+        "landscape" => cfg.landscape_levels() * (cfg.max_dim() + 1),
+        "image" => {
+            let res = cfg.image_resolution().max(1);
+            (cfg.max_dim() + 1) * res * res
+        }
+        _ => 0,
+    }
+}
+
+fn searchsorted_right(arr: &[i64], hi: usize, target: i64) -> usize {
+    let mut lo = 0usize;
+    let mut hi_mut = hi.min(arr.len());
+    while lo < hi_mut {
+        let mid = (lo + hi_mut) / 2;
+        if arr[mid] <= target {
+            lo = mid + 1;
+        } else {
+            hi_mut = mid;
+        }
+    }
+    lo
+}
+
+fn compute_liquidity_surface(slab: ArrayView2<f64>, cfg: &RollingConfig) -> Array2<f64> {
+    let t = slab.nrows();
+    let f = slab.ncols();
+    if f == 0 {
+        return Array2::<f64>::zeros((t, 0));
+    }
+    let mut levels = cfg.levels_hint().unwrap_or(0);
+    if levels == 0 {
+        for cand in [10usize, 20, 40] {
+            if 2 * cand <= f {
+                levels = cand;
+                break;
+            }
+        }
+        if levels == 0 {
+            levels = f / 2;
+        }
+    }
+    let max_levels = (f / 2).max(1);
+    let levels = levels.max(1).min(max_levels);
+    let end = (2 * levels).min(f);
+    if end <= levels {
+        return slab.to_owned();
+    }
+    let bids = slab.slice(s![.., 0..levels]).to_owned();
+    let asks = slab.slice(s![.., levels..end]).to_owned();
+    match cfg.cubical_scalar_field() {
+        "bid" => bids,
+        "ask" => asks,
+        "net" => bids - asks,
+        _ => {
+            let eps = cfg.imbalance_eps();
+            let mut out = bids.clone();
+            out.zip_mut_with(&asks, |b, a| {
+                let denom = b.abs() + a.abs() + eps;
+                if denom.abs() < f64::EPSILON {
+                    *b = 0.0;
+                } else {
+                    *b = (*b - *a) / denom;
+                }
+            });
+            out
+        }
+    }
+}
+
+fn quantile(values: &mut [f64], q: f64) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let q = q.clamp(0.0, 1.0);
+    let n = values.len();
+    let pos = q * ((n - 1) as f64);
+    let lower = pos.floor() as usize;
+    let upper = pos.ceil() as usize;
+    values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+    if lower == upper {
+        values[lower]
+    } else {
+        let weight = pos - (lower as f64);
+        values[lower] * (1.0 - weight) + values[upper] * weight
+    }
+}
+
+fn vectorise_diagram(
+    diag: &[Vec<(f64, f64)>],
+    cfg: &RollingConfig,
+    birth_range: Option<(f64, f64)>,
+    pers_range: Option<(f64, f64)>,
+) -> Vec<f32> {
+    match cfg.persistence_representation.as_str() {
+        "landscape" => {
+            let mut out: Vec<f32> =
+                Vec::with_capacity(cfg.landscape_levels() * (cfg.max_dim() + 1));
+            for d in 0..=cfg.max_dim() {
+                if d < diag.len() {
+                    let slice = &diag[d];
+                    let tmp = compute_landscape(
+                        slice,
+                        cfg.landscape_levels(),
+                        cfg.landscape_resolution(),
+                        cfg.landscape_summary(),
+                    );
+                    out.extend_from_slice(&tmp);
+                } else {
+                    out.extend(std::iter::repeat(0.0f32).take(cfg.landscape_levels()));
+                }
+            }
+            out
+        }
+        "image" => {
+            let res = cfg.image_resolution();
+            let mut out: Vec<f32> = Vec::with_capacity((cfg.max_dim() + 1) * res * res);
+            for d in 0..=cfg.max_dim() {
+                if d < diag.len() {
+                    let slice = &diag[d];
+                    let mut births: Vec<f64> = Vec::with_capacity(slice.len());
+                    let mut pers: Vec<f64> = Vec::with_capacity(slice.len());
+                    for &(b, p) in slice.iter() {
+                        births.push(b);
+                        pers.push(p);
+                    }
+                    let img = compute_image(
+                        &births,
+                        &pers,
+                        res,
+                        cfg.image_bandwidth(),
+                        birth_range,
+                        pers_range,
+                    );
+                    out.extend_from_slice(&img);
+                } else {
+                    out.extend(std::iter::repeat(0.0f32).take(res * res));
+                }
+            }
+            out
+        }
+        _ => vec![0.0f32; embedding_dim(cfg)],
+    }
+}
+
+fn compute_cubical_diagrams_py(
+    field: ArrayView2<f64>,
+    cfg: &RollingConfig,
+    gudhi: &Py<PyModule>,
+) -> PyResult<Vec<Vec<(f64, f64)>>> {
+    let max_dim = cfg.max_dim();
+    Python::with_gil(|py| {
+        let dims = field.shape();
+        let dims_tuple = PyTuple::new(py, dims.iter().map(|d| d.to_object(py)));
+        let top_cells: Vec<f64> = field.iter().cloned().collect();
+        let cells = PyArray1::from_vec(py, top_cells);
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("dimensions", dims_tuple)?;
+        kwargs.set_item("top_dimensional_cells", cells)?;
+        let cls = gudhi.as_ref(py).getattr("CubicalComplex")?;
+        let cc = cls.call((), Some(kwargs))?;
+        cc.call_method0("persistence")?;
+        let mut out: Vec<Vec<(f64, f64)>> = Vec::with_capacity(max_dim + 1);
+        for dim in 0..=max_dim {
+            let intervals = cc.call_method1("persistence_intervals_in_dimension", (dim,))?;
+            let list = intervals.downcast::<PyList>()?;
+            let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(list.len());
+            for item in list.iter() {
+                let tuple = item.extract::<(f64, f64)>()?;
+                let birth = tuple.0;
+                let death = tuple.1;
+                if birth.is_finite() && death.is_finite() {
+                    let pers = death - birth;
+                    if pers.is_finite() {
+                        pairs.push((birth, pers));
+                    }
+                }
+            }
+            out.push(pairs);
+        }
+        Ok(out)
+    })
+}
+
+fn compute_vr_diagrams_py(
+    points: ArrayView2<f64>,
+    cfg: &RollingConfig,
+    ripser: &Py<PyAny>,
+) -> PyResult<Vec<Vec<(f64, f64)>>> {
+    let n = points.nrows();
+    if n < 3 {
+        return Ok(vec![Vec::new(); cfg.max_dim() + 1]);
+    }
+    let mut data = points.to_owned();
+    if cfg.vr_zscore() {
+        for mut col in data.axis_iter_mut(Axis(1)) {
+            let mut mean = 0.0;
+            let mut count = 0.0;
+            for v in col.iter() {
+                if v.is_finite() {
+                    mean += *v;
+                    count += 1.0;
+                }
+            }
+            if count > 0.0 {
+                mean /= count;
+            }
+            let mut var = 0.0;
+            for v in col.iter() {
+                if v.is_finite() {
+                    let diff = *v - mean;
+                    var += diff * diff;
+                }
+            }
+            if count > 1.0 {
+                var /= count - 1.0;
+            }
+            let std = if var <= 0.0 { 1.0 } else { var.sqrt() };
+            for v in col.iter_mut() {
+                *v = (*v - mean) / std;
+            }
+        }
+    }
+    let eps = if cfg.vr_auto_epsilon() && n >= 2 {
+        match cfg.vr_epsilon_rule() {
+            "largest_cc" => Some(epsilon_for_lcc_impl(&data, cfg.vr_lcc_threshold())),
+            _ => Some(estimate_vr_epsilon_impl(
+                &data,
+                cfg.vr_connectivity_quantile(),
+            )),
+        }
+    } else {
+        None
+    };
+    Python::with_gil(|py| {
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("maxdim", cfg.max_dim())?;
+        kwargs.set_item("metric", "euclidean")?;
+        if let Some(eps) = eps {
+            if eps.is_finite() && eps > 0.0 {
+                kwargs.set_item("thresh", eps)?;
+            }
+        }
+        let arr = PyArray2::from_array(py, &data);
+        let res = ripser.as_ref(py).call((arr,), Some(kwargs))?;
+        let dgms_obj = res.get_item("dgms")?;
+        let dgms_list = dgms_obj.downcast::<PyList>()?;
+        let mut out: Vec<Vec<(f64, f64)>> = Vec::with_capacity(cfg.max_dim() + 1);
+        for dim in 0..=cfg.max_dim() {
+            match dgms_list.get_item(dim) {
+                Ok(item) => {
+                    let arr = item.downcast::<PyArray2<f64>>()?;
+                    let view = unsafe { arr.as_array() };
+                    let mut pairs: Vec<(f64, f64)> = Vec::with_capacity(view.shape()[0]);
+                    for row in view.rows() {
+                        let birth = row[0];
+                        let death = row[1];
+                        if birth.is_finite() && death.is_finite() {
+                            let pers = death - birth;
+                            if pers.is_finite() {
+                                pairs.push((birth, pers));
+                            }
+                        }
+                    }
+                    out.push(pairs);
+                }
+                Err(_) => out.push(Vec::new()),
+            }
+        }
+        Ok(out)
+    })
+}
+
+fn compute_image(
+    births: &[f64],
+    pers: &[f64],
+    resolution: usize,
+    sigma: f64,
+    birth_range: Option<(f64, f64)>,
+    pers_range: Option<(f64, f64)>,
+) -> Vec<f32> {
+    let n = births.len().min(pers.len());
+    let mut points: Vec<(f64, f64, f64)> = Vec::with_capacity(n);
+    for i in 0..n {
+        let b = births[i];
+        let p = pers[i];
+        if b.is_finite() && p.is_finite() {
+            points.push((b, p, p.max(0.0)));
+        }
+    }
+    let res = resolution.max(1);
+    if points.is_empty() {
+        return vec![0.0f32; res * res];
+    }
+
+    let (b_lo, mut b_hi) = birth_range.unwrap_or_else(|| {
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for &(b, _, _) in points.iter() {
+            lo = lo.min(b);
+            hi = hi.max(b);
+        }
+        if !lo.is_finite() || !hi.is_finite() {
+            (0.0, 1.0)
+        } else {
+            (lo, hi)
+        }
+    });
+    let (p_lo, mut p_hi) = pers_range.unwrap_or_else(|| {
+        let mut lo = f64::INFINITY;
+        let mut hi = f64::NEG_INFINITY;
+        for &(_, p, _) in points.iter() {
+            lo = lo.min(p);
+            hi = hi.max(p);
+        }
+        if !lo.is_finite() || !hi.is_finite() {
+            (0.0, 1.0)
+        } else {
+            (lo, hi)
+        }
+    });
+    if b_hi <= b_lo {
+        b_hi = b_lo + 1.0;
+    }
+    if p_hi <= p_lo {
+        p_hi = p_lo + 1.0;
+    }
+
+    let mut grid = Array2::<f64>::zeros((res, res));
+    let sigma = sigma.abs().max(1e-9);
+    let inv_sigma_sq = 1.0 / (2.0 * sigma * sigma);
+    let dx = if res > 1 {
+        (b_hi - b_lo) / ((res - 1) as f64)
+    } else {
+        1.0
+    };
+    let dy = if res > 1 {
+        (p_hi - p_lo) / ((res - 1) as f64)
+    } else {
+        1.0
+    };
+
+    grid.axis_iter_mut(Axis(0))
+        .into_par_iter()
+        .enumerate()
+        .for_each(|(iy, mut row)| {
+            let py = p_lo + (iy as f64) * dy;
+            for (ix, val) in row.iter_mut().enumerate() {
+                let px = b_lo + (ix as f64) * dx;
+                let mut acc = 0.0f64;
+                for &(b, p, w) in points.iter() {
+                    let db = px - b;
+                    let dp = py - p;
+                    let dist2 = db * db + dp * dp;
+                    acc += (-dist2 * inv_sigma_sq).exp() * w;
+                }
+                *val = acc;
+            }
+        });
+
+    grid.iter().map(|v| *v as f32).collect()
+}
+
+fn compute_landscape(
+    diagram: &[(f64, f64)],
+    k: usize,
+    resolution: usize,
+    summary_mode: &str,
+) -> Vec<f32> {
+    let levels = k.max(1);
+    if diagram.is_empty() {
+        return vec![0.0f32; levels];
+    }
+    let mut pts: Vec<(f64, f64)> = Vec::with_capacity(diagram.len());
+    for &(b, p) in diagram.iter() {
+        let death = b + p;
+        if b.is_finite() && death.is_finite() && death > b {
+            pts.push((b, death));
+        }
+    }
+    if pts.is_empty() {
+        return vec![0.0f32; levels];
+    }
+    let mut x_min = f64::INFINITY;
+    let mut x_max = f64::NEG_INFINITY;
+    for &(b, d) in pts.iter() {
+        x_min = x_min.min(b);
+        x_max = x_max.max(d);
+    }
+    if !x_min.is_finite() || !x_max.is_finite() {
+        x_min = 0.0;
+        x_max = 1.0;
+    }
+    if x_max <= x_min {
+        x_max = x_min + 1.0;
+    }
+    let res = resolution.max(2);
+    let mut xs = Vec::with_capacity(res);
+    for i in 0..res {
+        let x = if res == 1 {
+            (x_min + x_max) * 0.5
+        } else {
+            x_min + (x_max - x_min) * (i as f64) / ((res - 1) as f64)
+        };
+        xs.push(x);
+    }
+
+    let mut landscape = Array2::<f64>::zeros((levels, res));
+    landscape
+        .axis_iter_mut(Axis(1))
+        .into_par_iter()
+        .enumerate()
+        .for_each(|(xi, mut col)| {
+            col.fill(0.0);
+            let x = xs[xi];
+            let mut vals: Vec<f64> = Vec::with_capacity(pts.len());
+            for &(b, d) in pts.iter() {
+                if x <= b || x >= d {
+                    continue;
+                }
+                let left = x - b;
+                let right = d - x;
+                let val = left.min(right);
+                if val > 0.0 {
+                    vals.push(val);
+                }
+            }
+            if vals.is_empty() {
+                return;
+            }
+            vals.sort_by(|a, b| b.partial_cmp(a).unwrap());
+            for (level, slot) in col.iter_mut().enumerate() {
+                if level < vals.len() {
+                    *slot = vals[level];
+                } else {
+                    break;
+                }
+            }
+        });
+
+    let mut out = Vec::with_capacity(levels);
+    for row in landscape.axis_iter(Axis(0)) {
+        let summary = match summary_mode {
+            "max" => row.fold(0.0f64, |acc, &v| acc.max(v)),
+            _ => row.sum() / (res as f64),
+        };
+        out.push(summary as f32);
+    }
+    out
+}
+
+#[pyfunction]
+#[pyo3(signature = (births, pers, resolution, sigma, birth_range=None, pers_range=None))]
+fn persistence_image<'py>(
+    py: Python<'py>,
+    births: PyReadonlyArray1<f64>,
+    pers: PyReadonlyArray1<f64>,
+    resolution: usize,
+    sigma: f64,
+    birth_range: Option<(f64, f64)>,
+    pers_range: Option<(f64, f64)>,
+) -> PyResult<&'py PyArray1<f32>> {
+    let births_vec = births.as_array().to_vec();
+    let pers_vec = pers.as_array().to_vec();
+    let out = py.allow_threads(|| {
+        compute_image(
+            &births_vec,
+            &pers_vec,
+            resolution,
+            sigma,
+            birth_range,
+            pers_range,
+        )
+    });
+    Ok(PyArray1::from_vec(py, out))
+}
+
+#[pyfunction]
+#[pyo3(signature = (diagram, k, resolution, summary_mode="mean"))]
+fn persistence_landscape<'py>(
+    py: Python<'py>,
+    diagram: PyReadonlyArray2<f64>,
+    k: usize,
+    resolution: usize,
+    summary_mode: &str,
+) -> PyResult<&'py PyArray1<f32>> {
+    let diag_vec: Vec<(f64, f64)> = diagram
+        .as_array()
+        .rows()
+        .into_iter()
+        .map(|row| (row[0], row[1]))
+        .collect();
+    let out = py.allow_threads(|| compute_landscape(&diag_vec, k, resolution, summary_mode));
+    Ok(PyArray1::from_vec(py, out))
+}
+
+#[pyfunction]
+fn epsilon_for_lcc<'py>(
+    _py: Python<'py>,
+    x: PyReadonlyArray2<f64>,
+    threshold: f64,
+) -> PyResult<f64> {
+    let x = x.as_array();
+    Ok(epsilon_for_lcc_impl(&x.to_owned(), threshold))
+}
+
+#[pyfunction]
+#[pyo3(signature = (series, timestamps_ns, window_sizes_s, stride, cfg_json))]
+fn rolling_topo<'py>(
+    py: Python<'py>,
+    series: PyReadonlyArray2<f64>,
+    timestamps_ns: PyReadonlyArray1<i64>,
+    window_sizes_s: Vec<i64>,
+    stride: usize,
+    cfg_json: &str,
+) -> PyResult<&'py PyArray2<f32>> {
+    let cfg: RollingConfig = serde_json::from_str(cfg_json)
+        .map_err(|err| PyValueError::new_err(format!("invalid topology config: {err}")))?;
+    let stride = stride.max(1);
+    let n_rows = series.shape().get(0).copied().unwrap_or(0);
+    if n_rows == 0 {
+        let empty = Array2::<f32>::zeros((0, 0));
+        return Ok(PyArray2::from_owned_array(py, empty));
+    }
+    if window_sizes_s.is_empty() {
+        let empty = Array2::<f32>::zeros((n_rows, 0));
+        return Ok(PyArray2::from_owned_array(py, empty));
+    }
+    if cfg.persistence_representation != "image" && cfg.persistence_representation != "landscape" {
+        return Err(PyValueError::new_err(
+            "unsupported persistence representation",
+        ));
+    }
+    if cfg.complex_type != "cubical" && cfg.complex_type != "vietoris_rips" {
+        return Err(PyValueError::new_err("unsupported complex type"));
+    }
+
+    let series_arr = series.as_array().to_owned();
+    let ts_vec = timestamps_ns.as_array().to_vec();
+    let embed_per_window = embedding_dim(&cfg);
+    let total_embed = embed_per_window * window_sizes_s.len();
+    let mut output = vec![0.0f32; n_rows * total_embed];
+    let dims = cfg.max_dim() + 1;
+
+    let gudhi_module = if cfg.complex_type == "cubical" {
+        Some(py.import("gudhi")?.into_py(py))
+    } else {
+        None
+    };
+    let ripser_fn = if cfg.complex_type == "vietoris_rips" {
+        Some(py.import("ripser")?.getattr("ripser")?.into_py(py))
+    } else {
+        None
+    };
+
+    if cfg.complex_type == "cubical" && gudhi_module.is_none() {
+        return Err(PyValueError::new_err("gudhi module not available"));
+    }
+    if cfg.complex_type == "vietoris_rips" && ripser_fn.is_none() {
+        return Err(PyValueError::new_err("ripser module not available"));
+    }
+
+    let series_arc = Arc::new(series_arr);
+    let ts_arc = Arc::new(ts_vec);
+
+    for (w_idx, w_sec) in window_sizes_s.iter().enumerate() {
+        if *w_sec < 0 {
+            return Err(PyValueError::new_err("window size must be non-negative"));
+        }
+        let window_ns = w_sec
+            .checked_mul(1_000_000_000)
+            .ok_or_else(|| PyValueError::new_err("window size overflow"))?;
+        let mut diag_store: Vec<Vec<Vec<(f64, f64)>>> = vec![vec![Vec::new(); dims]; n_rows];
+        let mut births_all: Vec<f64> = Vec::new();
+        let mut pers_all: Vec<f64> = Vec::new();
+        let need_auto = cfg.persistence_representation == "image"
+            && cfg.image_auto_range()
+            && (cfg.image_birth_range.is_none() || cfg.image_pers_range.is_none());
+        let indices: Vec<usize> = (0..n_rows).step_by(stride).collect();
+        let results: PyResult<Vec<(usize, Vec<Vec<(f64, f64)>>)>> = py.allow_threads(|| {
+            let cfg_ref = cfg.clone();
+            let series_ref = Arc::clone(&series_arc);
+            let ts_ref = Arc::clone(&ts_arc);
+            let gudhi_ref = gudhi_module.clone();
+            let ripser_ref = ripser_fn.clone();
+            indices
+                .into_par_iter()
+                .map(|idx| -> PyResult<(usize, Vec<Vec<(f64, f64)>>)> {
+                    let left = ts_ref[idx] - window_ns;
+                    let start = searchsorted_right(&ts_ref, idx + 1, left);
+                    if start > idx {
+                        return Ok((idx, vec![Vec::new(); cfg_ref.max_dim() + 1]));
+                    }
+                    let slab = series_ref.slice(s![start..idx + 1, ..]);
+                    let diag = if cfg_ref.complex_type == "cubical" {
+                        let field = if cfg_ref.use_liquidity_surface() {
+                            compute_liquidity_surface(slab, &cfg_ref)
+                        } else {
+                            slab.to_owned()
+                        };
+                        let module = gudhi_ref
+                            .as_ref()
+                            .ok_or_else(|| PyValueError::new_err("gudhi module not available"))?;
+                        compute_cubical_diagrams_py(field.view(), &cfg_ref, module)?
+                    } else {
+                        let ripser = ripser_ref
+                            .as_ref()
+                            .ok_or_else(|| PyValueError::new_err("ripser module not available"))?;
+                        compute_vr_diagrams_py(slab, &cfg_ref, ripser)?
+                    };
+                    Ok((idx, diag))
+                })
+                .collect()
+        });
+        let results = results?;
+        for (idx, diag) in results.into_iter() {
+            for d in 0..dims {
+                let data = if d < diag.len() {
+                    diag[d].clone()
+                } else {
+                    Vec::new()
+                };
+                if need_auto {
+                    for &(b, p) in data.iter() {
+                        if b.is_finite() && p.is_finite() {
+                            births_all.push(b);
+                            pers_all.push(p);
+                        }
+                    }
+                }
+                diag_store[idx][d] = data;
+            }
+        }
+
+        let mut birth_range = cfg.image_birth_range;
+        let mut pers_range = cfg.image_pers_range;
+        if cfg.persistence_representation == "image" {
+            if (birth_range.is_none() || pers_range.is_none())
+                && need_auto
+                && !births_all.is_empty()
+                && !pers_all.is_empty()
+            {
+                let mut bvals = births_all.clone();
+                let mut pvals = pers_all.clone();
+                let bmin = quantile(&mut bvals, 0.01);
+                let bmax = quantile(&mut bvals, 0.99);
+                let pmin = quantile(&mut pvals, 0.01);
+                let pmax = quantile(&mut pvals, 0.99);
+                birth_range = Some((bmin, bmax));
+                pers_range = Some((pmin, pmax));
+            }
+        }
+
+        for idx in (0..n_rows).step_by(stride) {
+            let vec = vectorise_diagram(&diag_store[idx], &cfg, birth_range, pers_range);
+            let offset = idx * total_embed + w_idx * embed_per_window;
+            if vec.len() == embed_per_window {
+                output[offset..offset + embed_per_window].copy_from_slice(&vec);
+            }
+        }
+    }
+
+    let arr = Array2::from_shape_vec((n_rows, total_embed), output)
+        .map_err(|_| PyValueError::new_err("invalid output shape"))?;
+    Ok(PyArray2::from_owned_array(py, arr))
 }
 
 #[pymodule]
@@ -153,69 +939,97 @@ fn torpedocode_tda(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(queue_age_series, m)?)?;
     m.add_function(wrap_pyfunction!(queue_age_series_with_halts, m)?)?;
     m.add_function(wrap_pyfunction!(queue_age_levels, m)?)?;
+    m.add_function(wrap_pyfunction!(persistence_image, m)?)?;
+    m.add_function(wrap_pyfunction!(persistence_landscape, m)?)?;
+    m.add_function(wrap_pyfunction!(rolling_topo, m)?)?;
     Ok(())
 }
 
 #[pyfunction]
-fn queue_age_series(sz: PyReadonlyArray1<f64>, pr: PyReadonlyArray1<f64>, dt: PyReadonlyArray1<f32>) -> PyResult<Vec<f32>> {
+fn queue_age_series(
+    sz: PyReadonlyArray1<f64>,
+    pr: PyReadonlyArray1<f64>,
+    dt: PyReadonlyArray1<f32>,
+) -> PyResult<Vec<f32>> {
     let sz = sz.as_array();
     let pr = pr.as_array();
     let dt = dt.as_array();
     let n = sz.len();
     let mut age = vec![0.0f32; n];
-    if n == 0 { return Ok(age); }
+    if n == 0 {
+        return Ok(age);
+    }
     for i in 1..n {
-        let s_changed = sz[i] != sz[i-1];
+        let s_changed = sz[i] != sz[i - 1];
         let p_i = pr[i];
-        let p_prev = pr[i-1];
+        let p_prev = pr[i - 1];
         let p_changed = !p_i.is_finite() || !p_prev.is_finite() || (p_i != p_prev);
         if s_changed || p_changed {
             age[i] = 0.0;
         } else {
-            age[i] = age[i-1] + dt[i].max(0.0);
+            age[i] = age[i - 1] + dt[i].max(0.0);
         }
     }
     Ok(age)
 }
 
 #[pyfunction]
-fn queue_age_series_with_halts(sz: PyReadonlyArray1<f64>, pr: PyReadonlyArray1<f64>, dt: PyReadonlyArray1<f32>, halted: PyReadonlyArray1<bool>) -> PyResult<Vec<f32>> {
+fn queue_age_series_with_halts(
+    sz: PyReadonlyArray1<f64>,
+    pr: PyReadonlyArray1<f64>,
+    dt: PyReadonlyArray1<f32>,
+    halted: PyReadonlyArray1<bool>,
+) -> PyResult<Vec<f32>> {
     let sz = sz.as_array();
     let pr = pr.as_array();
     let dt = dt.as_array();
     let halted = halted.as_array();
     let n = sz.len();
     let mut age = vec![0.0f32; n];
-    if n == 0 { return Ok(age); }
+    if n == 0 {
+        return Ok(age);
+    }
     for i in 1..n {
-        let s_changed = sz[i] != sz[i-1];
+        let s_changed = sz[i] != sz[i - 1];
         let p_i = pr[i];
-        let p_prev = pr[i-1];
+        let p_prev = pr[i - 1];
         let p_changed = !p_i.is_finite() || !p_prev.is_finite() || (p_i != p_prev);
         if halted.get(i).copied().unwrap_or(false) || s_changed || p_changed {
             age[i] = 0.0;
         } else {
-            age[i] = age[i-1] + dt[i].max(0.0);
+            age[i] = age[i - 1] + dt[i].max(0.0);
         }
     }
     Ok(age)
 }
 
 #[pyfunction]
-fn queue_age_levels(sz: PyReadonlyArray2<f64>, pr: PyReadonlyArray2<f64>, dt: PyReadonlyArray1<f32>, halted: Option<PyReadonlyArray1<bool>>) -> PyResult<Vec<f32>> {
+fn queue_age_levels(
+    sz: PyReadonlyArray2<f64>,
+    pr: PyReadonlyArray2<f64>,
+    dt: PyReadonlyArray1<f32>,
+    halted: Option<PyReadonlyArray1<bool>>,
+) -> PyResult<Vec<f32>> {
     let sz = sz.as_array();
     let pr = pr.as_array();
     let dt = dt.as_array();
     let (t, l) = (sz.nrows(), sz.ncols());
     let mut out = vec![0.0f32; t * l];
-    if t == 0 || l == 0 { return Ok(out); }
+    if t == 0 || l == 0 {
+        return Ok(out);
+    }
     let halted_opt = halted.as_ref().map(|h| h.as_array());
     for i in 1..t {
         let dti = dt[i].max(0.0);
         let halt = halted_opt.map(|h| h[i]).unwrap_or(false);
         for j in 0..l {
             let idx = i * l + j;
-            if halt || sz[(i,j)] != sz[(i-1,j)] || pr[(i,j)] != pr[(i-1,j)] || !pr[(i,j)].is_finite() || !pr[(i-1,j)].is_finite() {
+            if halt
+                || sz[(i, j)] != sz[(i - 1, j)]
+                || pr[(i, j)] != pr[(i - 1, j)]
+                || !pr[(i, j)].is_finite()
+                || !pr[(i - 1, j)].is_finite()
+            {
                 out[idx] = 0.0;
             } else {
                 out[idx] = out[idx - l] + dti;

--- a/tests/test_persistence_native.py
+++ b/tests/test_persistence_native.py
@@ -1,0 +1,181 @@
+import math
+
+import numpy as np
+import pytest
+
+from torpedocode.config import TopologyConfig
+import torpedocode.features.topological as topo
+
+
+tda = pytest.importorskip("torpedocode_tda")
+
+
+def _ref_persistence_image(births, pers, resolution, sigma, birth_range=None, pers_range=None):
+    births = np.asarray(births, dtype=float)
+    pers = np.asarray(pers, dtype=float)
+    n = min(births.size, pers.size)
+    points = []
+    for i in range(n):
+        b = float(births[i])
+        p = float(pers[i])
+        if math.isfinite(b) and math.isfinite(p):
+            points.append((b, p, max(p, 0.0)))
+    res = max(int(resolution), 1)
+    if not points:
+        return np.zeros((res * res,), dtype=np.float32)
+
+    if birth_range is None:
+        b_lo = min(b for b, _, _ in points)
+        b_hi = max(b for b, _, _ in points)
+    else:
+        b_lo, b_hi = map(float, birth_range)
+    if not math.isfinite(b_lo) or not math.isfinite(b_hi) or b_hi <= b_lo:
+        b_lo, b_hi = float(b_lo), float(b_lo + 1.0)
+
+    if pers_range is None:
+        p_lo = min(p for _, p, _ in points)
+        p_hi = max(p for _, p, _ in points)
+    else:
+        p_lo, p_hi = map(float, pers_range)
+    if not math.isfinite(p_lo) or not math.isfinite(p_hi) or p_hi <= p_lo:
+        p_lo, p_hi = float(p_lo), float(p_lo + 1.0)
+
+    dx = (b_hi - b_lo) / (res - 1) if res > 1 else 1.0
+    dy = (p_hi - p_lo) / (res - 1) if res > 1 else 1.0
+    sigma = abs(float(sigma)) or 1e-9
+    inv_sigma_sq = 1.0 / (2.0 * sigma * sigma)
+
+    out = np.zeros((res, res), dtype=np.float64)
+    for iy in range(res):
+        py = p_lo + iy * dy
+        for ix in range(res):
+            px = b_lo + ix * dx
+            acc = 0.0
+            for b, p, w in points:
+                db = px - b
+                dp = py - p
+                acc += math.exp(-(db * db + dp * dp) * inv_sigma_sq) * w
+            out[iy, ix] = acc
+    return out.astype(np.float32).ravel()
+
+
+def _ref_persistence_landscape(diagram, k, resolution, summary_mode="mean"):
+    diag = np.asarray(diagram, dtype=float)
+    levels = max(int(k), 1)
+    if diag.size == 0:
+        return np.zeros((levels,), dtype=np.float32)
+
+    pts = []
+    for row in diag:
+        b = float(row[0])
+        p = float(row[1])
+        d = b + p
+        if math.isfinite(b) and math.isfinite(d) and d > b:
+            pts.append((b, d))
+    if not pts:
+        return np.zeros((levels,), dtype=np.float32)
+
+    x_min = min(b for b, _ in pts)
+    x_max = max(d for _, d in pts)
+    if not math.isfinite(x_min) or not math.isfinite(x_max) or x_max <= x_min:
+        x_min, x_max = float(x_min), float(x_min + 1.0)
+
+    res = max(int(resolution), 2)
+    xs = np.linspace(x_min, x_max, res)
+    values = np.zeros((levels, res), dtype=np.float64)
+    for xi, x in enumerate(xs):
+        vals = []
+        for b, d in pts:
+            if x <= b or x >= d:
+                continue
+            left = x - b
+            right = d - x
+            val = left if left < right else right
+            if val > 0.0:
+                vals.append(val)
+        if vals:
+            vals.sort(reverse=True)
+            for level in range(min(levels, len(vals))):
+                values[level, xi] = vals[level]
+
+    if summary_mode == "max":
+        summary = values.max(axis=1)
+    else:
+        summary = values.mean(axis=1)
+    return summary.astype(np.float32)
+
+
+def test_persistence_image_native_matches_reference():
+    births = np.array([0.05, 0.2, 0.7], dtype=float)
+    pers = np.array([0.1, 0.05, 0.3], dtype=float)
+    res = 32
+    sigma = 0.07
+    birth_range = (0.0, 1.0)
+    pers_range = (0.0, 0.5)
+
+    native = np.asarray(
+        tda.persistence_image(births, pers, res, sigma, birth_range, pers_range),
+        dtype=np.float32,
+    )
+    ref = _ref_persistence_image(births, pers, res, sigma, birth_range, pers_range)
+    np.testing.assert_allclose(native, ref, rtol=1e-5, atol=1e-6)
+
+
+def test_persistence_landscape_native_matches_reference():
+    diagram = np.array([[0.05, 0.15], [0.2, 0.3], [0.1, 0.05]], dtype=float)
+    k = 3
+    resolution = 64
+    for summary_mode in ("mean", "max"):
+        native = np.asarray(
+            tda.persistence_landscape(diagram, k, resolution, summary_mode),
+            dtype=np.float32,
+        )
+        ref = _ref_persistence_landscape(diagram, k, resolution, summary_mode)
+        np.testing.assert_allclose(native, ref, rtol=1e-6, atol=1e-6)
+
+
+def _rolling_reference_and_native(cfg: TopologyConfig, timestamps: np.ndarray, series: np.ndarray, monkeypatch) -> tuple[np.ndarray, np.ndarray]:
+    native_mod = topo._tda_native
+    if native_mod is None:
+        pytest.skip("torpedocode_tda native module unavailable")
+    monkeypatch.setattr(topo, "_tda_native", None)
+    gen_py = topo.TopologicalFeatureGenerator(cfg)
+    ref = gen_py.rolling_transform(timestamps, series)
+    monkeypatch.setattr(topo, "_tda_native", native_mod)
+    gen_native = topo.TopologicalFeatureGenerator(cfg)
+    out = gen_native.rolling_transform(timestamps, series)
+    return ref, out
+
+
+def test_rolling_transform_native_cubical_matches_python(monkeypatch):
+    pytest.importorskip("gudhi")
+    cfg = TopologyConfig(
+        window_sizes_s=[1, 2],
+        complex_type="cubical",
+        persistence_representation="landscape",
+        landscape_levels=3,
+        max_homology_dimension=1,
+    )
+    rng = np.random.default_rng(123)
+    series = rng.standard_normal((12, 20)).astype(np.float32)
+    timestamps = (np.arange(series.shape[0], dtype=np.int64) * 1_000_000_000)
+    ref, out = _rolling_reference_and_native(cfg, timestamps, series, monkeypatch)
+    np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)
+
+
+def test_rolling_transform_native_vr_image_matches_python(monkeypatch):
+    pytest.importorskip("ripser")
+    pytest.importorskip("persim")
+    cfg = TopologyConfig(
+        window_sizes_s=[1, 2],
+        complex_type="vietoris_rips",
+        persistence_representation="image",
+        image_resolution=8,
+        image_bandwidth=0.05,
+        max_homology_dimension=1,
+    )
+    rng = np.random.default_rng(321)
+    series = rng.standard_normal((10, 6)).astype(np.float32)
+    timestamps = (np.arange(series.shape[0], dtype=np.int64) * 1_000_000_000)
+    ref, out = _rolling_reference_and_native(cfg, timestamps, series, monkeypatch)
+    np.testing.assert_allclose(out, ref, rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
## Summary
- extend the torpedocode_tda crate with a RollingConfig helper and a new rolling_topo pyfunction that batches cubical and Vietoris–Rips windows, computes diagrams via gudhi/ripser, and vectorises with the native landscape/image kernels
- update TopologicalFeatureGenerator.rolling_transform to delegate to the native rolling_topo driver when available while preserving the existing Python fallback path
- add regression tests comparing native rolling outputs against the Python implementation for both cubical landscapes and VR images

## Testing
- uv run --extra dev python -m pytest -q

------