### PR TITLE
Optimize TDA rolling windows and persistence image fallback

### DIFF
--- a/python/torpedocode/config.py
+++ b/python/torpedocode/config.py
@@ -60,6 +60,8 @@ class TopologyConfig:
     image_auto_range: bool = True
     image_birth_range: tuple[float, float] | None = None
     image_pers_range: tuple[float, float] | None = None
+    # Number of windows to sample when estimating automatic image ranges; 0 uses all
+    image_auto_sample_limit: int = 2048
     strict_tda: bool = False
     vr_auto_epsilon: bool = True
     vr_connectivity_quantile: float = 0.99


### PR DESCRIPTION
## Summary
- add an `image_auto_sample_limit` topology configuration knob to throttle how many windows are used when estimating automatic persistence-image ranges
- speed up `TopologicalFeatureGenerator.rolling_transform` by reusing vectorised window indices, skipping degenerate Vietoris–Rips slabs, and sampling windows for auto-range estimation instead of recomputing diagrams for every window
- vectorise the pure-Python persistence image fallback so it bins diagram points without per-point Python loops while preserving per-dimension outputs